### PR TITLE
Added online environment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+- init: make
+  command: build/2048-in-terminal

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 `sudo make install`
 
+Run it in a free online dev environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/alewmoose/2048-in-terminal)
 
 ## The original game:
 http://gabrielecirulli.github.io/2048/


### PR DESCRIPTION
This PR adds a config to be able to open and code on the repo from within the browser using Gitpod (Disclaimer: I work on it).

I'd like to share your game with the community as it is a fun example also this makes it easier for anybody to give it a try without going local through manual steps (e.g. installing make).

You can open any github repository, issue or pull request with Gitpod, just by prefixing the github URL with `https://gitpod.io/#'.

For instance you can review this PR using it:

https://gitpod.io/#https://github.com/alewmoose/2048-in-terminal/pull/3