### PR TITLE
Makefile: tweak usage of implicit variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ OBJ=$(SRC:$(SRCDIR)/%.c=$(BUILDDIR)/%.o)
 DEP=$(SRC:$(SRCDIR)/%.c=$(BUILDDIR)/%.d)
 
 NCURSES_LIB?=ncurses
-NCURSES_CFLAGS?=`pkg-config --cflags $(NCURSES_LIB)`
-NCURSES_LDLIBS?=`pkg-config --libs $(NCURSES_LIB)`
+NCURSES_CFLAGS?=$(shell pkg-config --cflags $(NCURSES_LIB))
+NCURSES_LDLIBS?=$(shell pkg-config --libs $(NCURSES_LIB))
 
-CFLAGS?=-Wall -Wextra -pedantic -std=c11 -O2 -march=native -D_GNU_SOURCE $(NCURSES_CFLAGS)
-LDLIBS?=$(NCURSES_LDLIBS)
+CFLAGS+= -Wall -Wextra -pedantic -std=c11 -D_GNU_SOURCE $(NCURSES_CFLAGS)
+LDLIBS+= $(NCURSES_LDLIBS)
 
 PREFIX?=/usr/local
 BINDIR?=$(PREFIX)/bin
@@ -25,13 +25,13 @@ BINDIR?=$(PREFIX)/bin
 all: $(TARGET)
 
 $(TARGET): $(OBJ)
-	$(CC) $(CFLAGS) $^ -o $(TARGET) $(LDLIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^ -o $(TARGET) $(LDLIBS)
 
 %.o : %.c
 
 $(BUILDDIR)/%.o: $(SRCDIR)/%.c $(BUILDDIR)/%.d
 	$(CC) -MM $< -MQ $(BUILDDIR)/$*.o -MF $(BUILDDIR)/$*.d
-	$(CC) -c $(CFLAGS) $< -o $@
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
 %.d: ;
 


### PR DESCRIPTION
Just some minor tweaks to make building, with user-defined optimizations (in `CFLAGS` et al), a bit easier.

Carrying a similar patch here: https://aur.archlinux.org/packages/2048term-git

> There are CFLAGS required for correct compilation, so append rather than conditionally assign. Remove optimizer and like flags from Makefile-- users can pass these in if they like (e.g. from their environment).
>
> Same with LDLIBS-- append instead of conditional assignment.
>
> For the NCURSES_ variables, use make's shell function instead of backticks for expansion.
>
> Add CPPFLAGS and LDFLAGS implicit variables to the default target, allowing more user flexibility.
